### PR TITLE
Remove hardcoded \Exception type hinting.

### DIFF
--- a/src/error_handlers.php
+++ b/src/error_handlers.php
@@ -18,10 +18,10 @@
  * @param $errstr
  * @param $errfile
  * @param $errline
- * @param $e Used when this is a user-generated error from an uncaught exception
+ * @param \Exception|\Error $e Used when this is a user-generated error from an uncaught exception
  * @return boolean
  */
-function daemon_error($errno, $errstr, $errfile, $errline, $errcontext = null, \Exception $e = null)
+function daemon_error($errno, $errstr, $errfile, $errline, $errcontext = null, $e = null)
 {
     static $runonce = true;
     static $is_writable = true;
@@ -105,10 +105,10 @@ function daemon_error($errno, $errstr, $errfile, $errline, $errcontext = null, \
 
 /**
  * Capture any uncaught exceptions and pass them as input to the error handler
- * @param Exception $e
+ * @param \Exception|\Error $e
  *
  */
-function daemon_exception(\Exception $e)
+function daemon_exception($e)
 {
     daemon_error(-1, $e->getMessage(), $e->getFile(), $e->getLine(), null, $e);
 }


### PR DESCRIPTION
PHP 7 changes how most errors are reported by PHP. Instead of reporting errors through the traditional error reporting mechanism used by PHP 5, most errors are now reported by throwing Error exceptions.
If error represented as the \Error class instead of \Exception instance we get the error:  ```PHP Fatal error:  Uncaught TypeError: Argument 6 passed to daemon_error() must be an instance of Exception or null, an instance of Error given```.
The fix allows passing \Exception or \Error objects as an argument.